### PR TITLE
Ignore future transactions since YNAB's API doesn't support them

### DIFF
--- a/src/Db.ts
+++ b/src/Db.ts
@@ -1,10 +1,10 @@
-import admin, {ServiceAccount} from 'firebase-admin';
+import admin, { ServiceAccount } from 'firebase-admin';
 import serviceAccount from '../firebase-service-account.json';
-import {IPersistedConfiguration, PersistedTransaction} from './types';
-import {Configuration} from './Configuration';
+import { IPersistedConfiguration, PersistedTransaction } from './types';
+import { Configuration } from './Configuration';
 import _ from 'lodash';
-import {CollectionReference} from '@google-cloud/firestore';
-import {DocumentSnapshot} from 'firebase-functions/lib/providers/firestore';
+import { CollectionReference } from '@google-cloud/firestore';
+import { DocumentSnapshot } from 'firebase-functions/lib/providers/firestore';
 
 admin.initializeApp({
     credential: admin.credential.cert(serviceAccount as ServiceAccount)
@@ -44,12 +44,14 @@ export default class Db {
 
     private async removeExistingTransactions(transactions: PersistedTransaction[], collection: CollectionReference) {
         const existingDocuments = await this.db.getAll(
-            ...transactions.map(x => collection.doc(this.getUniqueDbId(x)), {fieldMask: ['id']})
+            ...transactions.map(x => collection.doc(this.getUniqueDbId(x)), { fieldMask: ['id'] })
         );
 
         const existingTransactions = existingDocuments.filter(x => !!x.data()).map(this.mapDocument);
 
-        const newTransactions = _.differenceBy(transactions, existingTransactions, (x: PersistedTransaction) => this.getUniqueDbId(x));
+        const newTransactions = _.differenceBy(transactions, existingTransactions, (x: PersistedTransaction) =>
+            this.getUniqueDbId(x)
+        );
         return newTransactions;
     }
 
@@ -70,9 +72,7 @@ export default class Db {
 
     async getTransactions(startDate: Date, endDate?: Date): Promise<PersistedTransaction[]> {
         const collection = this.db.collection('transactions');
-        let query = collection
-            .orderBy('date')
-            .where('date', '>=', startDate);
+        let query = collection.orderBy('date').where('date', '>=', startDate);
 
         if (endDate) {
             query = query.where('date', '<=', endDate);
@@ -84,7 +84,7 @@ export default class Db {
 
     mapDocument(document: DocumentSnapshot) {
         const data = document.data()!;
-        return {...data, date: data.date.toDate()} as PersistedTransaction;
+        return { ...data, date: data.date.toDate() } as PersistedTransaction;
     }
 
     async getConfigurations(): Promise<Configuration[]> {

--- a/src/commands/changeIds.ts
+++ b/src/commands/changeIds.ts
@@ -1,20 +1,20 @@
-import Db from "../Db";
-import env from "../env";
-import shortid from "shortid";
-import {tryDebuggingLocally} from "../debug";
-import moment from "moment";
+import Db from '../Db';
+import env from '../env';
+import shortid from 'shortid';
+import { tryDebuggingLocally } from '../debug';
+import moment from 'moment';
 
-export const changeIds = tryDebuggingLocally(async function () {
+export const changeIds = tryDebuggingLocally(async function() {
     const db = new Db();
     const startDate = moment()
         .startOf('month')
         .subtract(env.MONTHS_TO_SCRAPE, 'months')
         .toDate();
 
-    const transactions = await db.getTransactions(startDate, undefined);
-    transactions.forEach(x=>{
+    const transactions = await db.getTransactions(startDate);
+    transactions.forEach(x => {
         x.id = shortid.generate();
     });
 
-    return db.addTransactions(transactions,true);
+    return db.addTransactions(transactions, true);
 });

--- a/src/commands/uploadToYnab.ts
+++ b/src/commands/uploadToYnab.ts
@@ -1,10 +1,10 @@
 import Db from '../Db';
-import {uploadTransactions} from '../ynab';
-import {PersistedTransaction} from '../types';
+import { uploadTransactions } from '../ynab';
+import { PersistedTransaction } from '../types';
 import _ from 'lodash';
 import env from '../env';
 import moment from 'moment';
-import {tryDebuggingLocally} from '../debug';
+import { tryDebuggingLocally } from '../debug';
 
 export const uploadToYnab = tryDebuggingLocally(async function() {
     const db = new Db();
@@ -14,7 +14,7 @@ export const uploadToYnab = tryDebuggingLocally(async function() {
         .subtract(env.MONTHS_TO_SCRAPE, 'months')
         .toDate();
 
-    let todayDate = moment().toDate();
+    const todayDate = moment().toDate();
     const transactions = await db.getTransactions(startDate, todayDate);
 
     for (const configuration of configurations) {


### PR DESCRIPTION
Leumicard's scraper sets an installment transaction date to to the day of month on which the purchase was made and thus sometimes returning transactions in the future.
For example:
Suppose I purchased car insurance at 10/05/19 in 12 installments of 100 NIS.
on June 1st, the scraper will return an installment transaction with the date 10/06/19 on it.

Uploading such a transaction to YNAB will return an 400 error code with an error message of "a transaction's date cannot be in the future"

My current solution is to filter future transactions, an alternative solution could be to create a "future" transaction in YNAB, but I didn't research the API in order to do so, I'll create a separate ticket to explore that...?